### PR TITLE
purge unmanaged resources in $conf_dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,7 @@ class monit (
     group   => 'root',
     mode    => '0755',
     require => Package[$monit::params::monit_package],
+    purge   => true,
   }
 
   # Not all platforms need this


### PR DESCRIPTION
Set `purge => true` on unmanaged resources in `$conf_dir` so that we don't have to go around deleting unrequired configs by hand anymore.