### PR TITLE
BIG-23190: add support for program checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+-   repo: git://github.com/pre-commit/mirrors-puppet-lint
+    sha: eb22b19d6d8927999eb590293b1533bd5ffdc56f
+    hooks:
+    -   id: puppet-lint
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: f82fb149af2c1b552b50e3e38e38ed3a44d4cda1
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-yaml
+    -   id: check-json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Alternatively you can specify a Unix socket to check:
       socket => "/var/run/gunicorn/blog.sock",
     }
 
+You can also call a script to execute:
+
+    monit::monitor { "docker-ecs-agent":
+      program => "/etc/monit/check-ecs-agent.sh
+    }
+
 You can also provide additional checks:
 
     $reload_blog = "/etc/init.d/gunicorn-blog reload"

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -6,6 +6,7 @@
 #
 # [*pidfile*]      - Path to the pid file for the service
 # [*matching*]     - String to match a process
+# [*program*]      - File to execute for check
 # [*ensure*]       - If the file should be enforced or not (default: present)
 # [*ip_port*]      - Port to check if needed (zero to disable)
 # [*socket*]       - Path to socket file if needed (undef to disable)
@@ -31,6 +32,7 @@
 define monit::monitor (
   $pidfile       = undef,
   $matching      = undef,
+  $program       = undef,
   $ensure        = present,
   $ip_port       = 0,
   $socket        = undef,
@@ -44,14 +46,14 @@ define monit::monitor (
   $gid           = '',
 ) {
   include monit::params
-  if ($pidfile == undef) and ($matching == undef) {
-    fail('Only one of pidfile and matching must be specified.')
+  if ($pidfile == undef) and ($matching == undef) and ($program == undef) {
+    fail('Only one of pidfile, matching or program must be specified.')
   }
-  if ($pidfile != undef) and ($matching != undef) {
-    fail('One of pidfile and matching must be specified.')
+  if ($pidfile != undef) and ($matching != undef) and ($program != undef) {
+    fail('Only one of pidfile, matching or program must be specified.')
   }
 
-  # Template uses: $pidfile, $ip_port, $socket, $checks, $start_script, $stop_script, $start_timeout, $stop_timeout, $group, $uid, $gid
+  # Template uses: $pidfile, $program, $ip_port, $socket, $checks, $start_script, $stop_script, $start_timeout, $stop_timeout, $group, $uid, $gid
   file { "${monit::params::conf_dir}/${name}.conf":
     ensure  => $ensure,
     content => template('monit/process.conf.erb'),

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -2,6 +2,8 @@
 check process <%= @name %> with pidfile <%= @pidfile %>
 <% elsif @matching -%>
 check process <%= @name %> matching <%= @matching %>
+<% elsif @program -%>
+check program <%= @name %> with path <%= @program %>
 <% end -%>
   start program = "<%= @start_script %>"<%= " as uid \"#{uid}\" and gid \"#{gid}\"" if uid != '' and gid != '' %>
 <% if @start_timeout -%>


### PR DESCRIPTION
Add support for Monit program checks

```
monit::monitor { 'docker-ecs-agent':
  program => '/etc/monit/check-ecs-agent.sh',
  start_script  => "/etc/init.d/docker-ecs-agent start",
  stop_script   => "/etc/init.d/docker-ecs-agent stop",
  checks  => [
    "if status != 0 then exec ${$dockerEcsAgentTrigger} else if passed then exec ${$dockerEcsAgentResolve}"
  ],
  require => [
    Service['docker'],
    Exec['pagerduty'],
    File['/etc/monit/check-ecs-agent.sh']
  ]
}
```

The above monitor will produce the following check:
```
check program docker-ecs-agent with path /etc/monit/check-ecs-agent.sh
  start program = "/etc/init.d/docker-ecs-agent start"
  stop program  = "/etc/init.d/docker-ecs-agent stop"
  if status != 0 then exec /bin/bash -c '/etc/monit/pagerduty-trigger.sh docker-ecs-agent && /etc/init.d/docker-ecs-agent start' else if passed then exec /bin/bash -c '/etc/monit/pagerduty-resolve.sh docker-ecs-agent'
  group docker-ecs-agent
```

ping @bc-techops @bc-cole @stevencorona @zackangelo 