### PR TITLE
Add bash completion script for monit command

### DIFF
--- a/files/monit-bash_completion
+++ b/files/monit-bash_completion
@@ -1,0 +1,44 @@
+have monit &&
+_monit() {
+    local cur prev special i
+
+    COMPREPLY=()
+    _get_comp_words_by_ref cur prev
+
+    for (( i=0; i < ${#COMP_WORDS[@]} - 1; i++ )); do
+        if [[ ${COMP_WORDS[i]} == @(start|stop|restart|monitor|unmonitor|status|summary|reload|quite|validate|procmatch|-c) ]]; then
+            local special=${COMP_WORDS[i]}
+        fi
+    done
+
+    if [ -n "$special" ]; then
+        case $special in
+            start|stop|restart|monitor|unmonitor)
+                # Don't bug the user for a password
+                sudo -n true > /dev/null 2>&1
+                if [[ $? == 0 ]]; then
+                    ALL="all"
+                    SERVICES=$(sudo monit summary | sed -n '/'\''/!{/\n/{P;b}};s/'\''/\n/g;D')
+                    SERVICES+=" all"
+                    COMPREPLY=( $(compgen -W "$SERVICES" -- "$cur"))
+                fi
+                return 0
+                ;;
+            -c) # Specify config file
+                _filedir
+                return 0
+                ;;
+            summary)
+                COMPREPLY=()
+                return 0
+                ;;
+        esac
+    fi
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W '-c -d -g -l -p -s -I -t -v -vv -H -V -h' -- $cur))
+    else
+        COMPREPLY=( $(compgen -W "start stop restart monitor unmonitor status summary reload quit validate procmatch" -- $cur))
+    fi
+}
+complete -F _monit monit

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,4 +108,11 @@ class monit (
       File[$monit::params::logrotate_script]
     ],
   }
+  file {'/etc/bash_completion.d/monit':
+    ensure => present,
+    source => "puppet:///modules/${module_name}/monit-bash_completion",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644'
+  }
 }


### PR DESCRIPTION
This PR adds in a bash completion script for `monit` command:
```
# monit <TAB><TAB>
monitor    procmatch  quit       reload     restart    start      status     stop       summary    unmonitor  validate   
```