### PR TITLE
Added START=yes

### DIFF
--- a/templates/monit.default.conf.ubuntu.maverick.erb
+++ b/templates/monit.default.conf.ubuntu.maverick.erb
@@ -5,6 +5,7 @@
 
 # You must set this variable to for monit to start
 startup=1
+START=yes
 
 # You can change the location of the state file here
 # It can also be set in monitrc


### PR DESCRIPTION
Newer versions of monit want START=yes to be present to start nicely. Adding it does not adversely affect older versions.