### PR TITLE
fix references to uid & gid in template

### DIFF
--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -5,7 +5,7 @@ check process <%= @name %> matching <%= @matching %>
 <% elsif @program -%>
 check program <%= @name %> with path <%= @program %>
 <% end -%>
-  start program = "<%= @start_script %>"<%= " as uid \"#{uid}\" and gid \"#{gid}\"" if uid != '' and gid != '' %>
+  start program = "<%= @start_script %>"<%= " as uid \"#{@uid}\" and gid \"#{@gid}\"" if @uid != '' and @gid != '' %>
 <% if @start_timeout -%>
     with timeout <%= @start_timeout %> seconds
 <% end -%>


### PR DESCRIPTION
Changing the references to `uid` and `gid` variables to make then instance variables to get rid of deprecation notices on the puppet master:
```
 Variable access via 'uid' is deprecated. Use '@uid' instead. template[/opt/puppet_envs/production/librarian-modules/monit/templates/process.conf.erb]:8
```