### PR TITLE
RFC: Restart a service after its config has changed.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,7 @@ class monit (
     ensure     => $service_state,
     enable     => $run_service,
     hasrestart => true,
+    restart    => '/etc/init.d/monit reload && sleep 3',
     hasstatus  => $monit::params::service_has_status,
     subscribe  => File[$monit::params::conf_file],
     require    => [

--- a/manifests/monitor.pp
+++ b/manifests/monitor.pp
@@ -58,7 +58,16 @@ define monit::monitor (
   file { "${monit::params::conf_dir}/${name}.conf":
     ensure  => $ensure,
     content => template('monit/process.conf.erb'),
-    notify  => Service[$monit::params::monit_service],
     require => Package[$monit::params::monit_package],
+    notify  => [
+      Service[$monit::params::monit_service],
+      Exec["restart monit service ${name}"],
+    ]
+  }
+
+  exec { "restart monit service ${name}":
+    command     => "/usr/bin/monit restart ${name}",
+    refreshonly => true,
+    require     => Service[$monit::params::monit_service],
   }
 }


### PR DESCRIPTION
This is a request for comment on a proposed change to how monit services are managed when they change. 

Currently if the definition of a service (such as its startup script) has changed, then the service doesn't get restarted.

This PR has two changes:
- use `monit reload` to load up new config rather than restarting the main monit service entirely. A sleep is also added to ensure monit has fully reloaded.
- use a notified exec to have monit restart the service that has changed

Logs of this change having modified two services:
```
==> monit.log <==
[CDT Apr 19 19:25:15] info     : Awakened by the SIGHUP signal
[CDT Apr 19 19:25:15] info     : Reinitializing Monit - Control file '/etc/monit/monitrc'
[CDT Apr 19 19:25:15] info     : Shutting down Monit HTTP server
[CDT Apr 19 19:25:15] info     : Monit HTTP server stopped
[CDT Apr 19 19:25:15] info     : Starting Monit HTTP server at [localhost:2812]
[CDT Apr 19 19:25:15] info     : Monit HTTP server started
[CDT Apr 19 19:25:15] info     : 'bcapp.dev' Monit reloaded
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_2' restart on user request
[CDT Apr 19 19:25:17] info     : Monit daemon with PID 5580 awakened
[CDT Apr 19 19:25:17] info     : Awakened by User defined signal 1
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_2' trying to restart
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_2' stop: /bin/sh

==> resque/worker_searchindexer_index_group1_2.log <==
[notice] Shutting down

==> monit.log <==
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_2' start: /usr/local/bin/start_resque_worker.sh
tail: resque/worker_searchindexer_index_group1_2.log: file truncated

==> monit.log <==
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_1' restart on user request
[CDT Apr 19 19:25:17] info     : Monit daemon with PID 5580 awakened

==> resque/worker_searchindexer_index_group1_2.log <==
[notice] Using reserver RandomQueueOrderReserver
[notice] Starting worker bcapp.dev:32170:searchindexer_bigcommerce_01_20160601_00,searchindexer_bigcommerce_02_20160601_00

==> monit.log <==
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_2' restart action done
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_1' trying to restart
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_1' stop: /bin/sh

==> resque/worker_searchindexer_index_group1_1.log <==
[notice] Shutting down

==> monit.log <==
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_1' start: /usr/local/bin/start_resque_worker.sh

tail: resque/worker_searchindexer_index_group1_1.log: file truncated
[notice] Using reserver RandomQueueOrderReserver
[notice] Starting worker bcapp.dev:32204:searchindexer_bigcommerce_01_20160601_00,searchindexer_bigcommerce_02_20160601_00

==> monit.log <==
[CDT Apr 19 19:25:17] info     : 'resque_worker_searchindexer_index_group1_1' restart action done
[CDT Apr 19 19:25:17] info     : Awakened by User defined signal 1
```

rfc @bisscuitt @chrisboulton @dsolsona 