### PR TITLE
bump stdlib and fix up some gem versions. fix a test.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,22 @@
 source 'https://rubygems.org'
 
-gem "puppet",             "< 4"
+gem "puppet",             "~> 4.10.12"
 gem "facter",             "< 3"
 gem 'safe_yaml',          "~> 1.0.4"
 
 # json_pure and json have been pinned to before version 2.0
 # as versions have no support for ruby 1.9.3 and greater
-gem 'json_pure', '< 2'
-gem 'json',      '< 2'
+#gem 'json_pure', '< 2'
+#gem 'json',      '< 2'
 
 
 group :test do
   gem 'puppet-lint'
-  gem 'rspec-puppet', '~> 0.1.3'
+  gem 'rspec-puppet', '~> 2.7.0'
   gem 'metadata-json-lint'
 end
 
 group :development, :test do
   gem 'rake'
-  gem 'puppetlabs_spec_helper', '<0.8'
+  gem 'puppetlabs_spec_helper'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,64 +1,76 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
-    diff-lcs (1.2.5)
-    facter (2.4.6)
-      CFPropertyList (~> 2.2.6)
-    hiera (1.3.4)
-      json_pure
-    json (1.8.3)
-    json_pure (1.8.3)
-    metaclass (0.0.4)
-    metadata-json-lint (0.0.11)
-      json
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    diff-lcs (1.4.4)
+    facter (2.5.7)
+    fast_gettext (1.1.2)
+    gettext (3.2.9)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.34)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2, < 3.3.0)
+      locale
+    hiera (3.6.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    json_pure (1.8.6)
+    locale (2.1.3)
+    metadata-json-lint (2.4.0)
+      json-schema (~> 2.8)
       spdx-licenses (~> 1.0)
-    mocha (1.1.0)
-      metaclass (~> 0.0.1)
-    puppet (3.8.7)
-      facter (> 1.6, < 3)
-      hiera (~> 1.0)
-      json_pure
-    puppet-lint (2.0.2)
-    puppetlabs_spec_helper (0.7.0)
-      mocha
-      puppet-lint
+    mocha (1.11.2)
+    pathspec (0.2.1)
+    public_suffix (4.0.6)
+    puppet (4.10.12)
+      facter (> 2.0, < 4)
+      gettext-setup (>= 0.10, < 1)
+      hiera (>= 2.0, < 4)
+      json_pure (~> 1.8)
+      locale (~> 2.1)
+    puppet-lint (2.4.2)
+    puppet-syntax (2.6.0)
       rake
-      rspec
-      rspec-puppet
-    rake (11.3.0)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.3)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    puppetlabs_spec_helper (2.15.0)
+      mocha (~> 1.0)
+      pathspec (~> 0.2.1)
+      puppet-lint (~> 2.0)
+      puppet-syntax (>= 2.0, < 4)
+      rspec-puppet (~> 2.0)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-puppet (0.1.6)
+      rspec-support (~> 3.9.0)
+    rspec-puppet (2.7.10)
       rspec
-    rspec-support (3.5.0)
-    safe_yaml (1.0.4)
-    spdx-licenses (1.1.0)
+    rspec-support (3.9.3)
+    safe_yaml (1.0.5)
+    spdx-licenses (1.2.0)
+    text (1.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   facter (< 3)
-  json (< 2)
-  json_pure (< 2)
   metadata-json-lint
-  puppet (< 4)
+  puppet (~> 4.10.12)
   puppet-lint
-  puppetlabs_spec_helper (< 0.8)
+  puppetlabs_spec_helper
   rake
-  rspec-puppet (~> 0.1.3)
+  rspec-puppet (~> 2.7.0)
   safe_yaml (~> 1.0.4)
 
 BUNDLED WITH
-   1.12.5
+   1.17.3

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "bigcommerce-monit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Bigcommerce - Technical Operations <techops@bigcommerce.com>",
   "summary": "BigCommerce Monit Module - Manages monit on the BigCommerce platform",
   "source": "https://github.com/bigcommerce/puppet-module-monit",
@@ -21,7 +21,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "< 5.0.0"
+      "version_requirement": "< 6.0.0"
     }
   ]
 }

--- a/spec/classes/monit_spec.rb
+++ b/spec/classes/monit_spec.rb
@@ -68,6 +68,7 @@ describe 'monit', :type => :class do
         :lsbdistid       => 'Debian',
         :kernel          => 'Linux',
         :operatingsystem => 'Debian',
+        :lsbdistcodename => 'jessie',
       }
     end
 


### PR DESCRIPTION
NOTE: this will be one of a few module updates in a single puppet MR
Related puppet MR:https://code.bigcommerce.net/techops/puppet/-/merge_requests/10869

## What
* Updates the Gemfile(.lock) with newer versions of `puppet` and `rspec-puppet`
* Takes away the version for `puppetlabs_spec_helper`
* bumps the module version and updates the upper end of the `puppetlabs-stdlib` version range
* minor fix to a test

## Impact
Only jessie machines use `monit` still so only they could be impacted but ultimately this just bumps files used for dependency calculation and testing

## Puppet output
same drill, see main puppet MR

## Proof of Life
Nothing changed. Nothing broken.